### PR TITLE
Alias search

### DIFF
--- a/lib/vagrant-ghost/Ghost.rb
+++ b/lib/vagrant-ghost/Ghost.rb
@@ -26,7 +26,7 @@ module VagrantPlugins
 				hostnames = Array(@machine.config.vm.hostname)
 
 				# Regenerate hosts from aliases file
-				paths = Dir[File.join( @machine.directory, '**', 'aliases' )]
+				paths = Dir[File.join( @machine.env.root_path.to_s, '**', 'aliases' )]
 				aliases = paths.map do |path|
 					lines = File.readlines(path).map(&:chomp)
 					lines.grep(/\A[^#]/)

--- a/lib/vagrant-ghost/Ghost.rb
+++ b/lib/vagrant-ghost/Ghost.rb
@@ -26,7 +26,7 @@ module VagrantPlugins
 				hostnames = Array(@machine.config.vm.hostname)
 
 				# Regenerate hosts from aliases file
-				paths = Dir[File.join( '**', 'aliases' )]
+				paths = Dir[File.join( @machine.directory, '**', 'aliases' )]
 				aliases = paths.map do |path|
 					lines = File.readlines(path).map(&:chomp)
 					lines.grep(/\A[^#]/)


### PR DESCRIPTION
If a vagrant command that triggers ghost is run in a subdirectory inside the vagrant root, Ghost can't find any `aliases` files outside of the CWD and won't add all expected addresses to the hosts file.
