### PR TITLE
Only scan an aliases path for hosts if it's a file

### DIFF
--- a/lib/vagrant-ghost/Ghost.rb
+++ b/lib/vagrant-ghost/Ghost.rb
@@ -28,8 +28,10 @@ module VagrantPlugins
 				# Regenerate hosts from aliases file
 				paths = Dir[File.join( @machine.env.root_path.to_s, '**', 'aliases' )]
 				aliases = paths.map do |path|
-					lines = File.readlines(path).map(&:chomp)
-					lines.grep(/\A[^#]/)
+					if File.file?(path)
+						lines = File.readlines(path).map(&:chomp)
+						lines.grep(/\A[^#]/)
+					end
 				end.flatten.uniq
 
 				# Concat with the local hostname


### PR DESCRIPTION
This fixes a bug @tlovett1 found where ghost errors out if there's a directory named `aliases` when it tries to read the contents of the directory inode.
