### PR TITLE
Add a configuration option to modify the filename containing hosts

### DIFF
--- a/lib/vagrant-ghost/Ghost.rb
+++ b/lib/vagrant-ghost/Ghost.rb
@@ -25,8 +25,10 @@ module VagrantPlugins
 			def getHostnames
 				hostnames = Array(@machine.config.vm.hostname)
 
+				hosts_files = @machine.config.ghost.hosts_files || 'aliases'
+
 				# Regenerate hosts from aliases file
-				paths = Dir[File.join( @machine.env.root_path.to_s, '**', 'aliases' )]
+				paths = Dir[File.join( @machine.env.root_path.to_s, '**', hosts_files )]
 				aliases = paths.map do |path|
 					lines = File.readlines(path).map(&:chomp)
 					lines.grep(/\A[^#]/)

--- a/lib/vagrant-ghost/config.rb
+++ b/lib/vagrant-ghost/config.rb
@@ -4,6 +4,7 @@ module VagrantPlugins
 	module Ghost
 		class Config < Vagrant.plugin("2", :config)
 			attr_accessor :hosts
+			attr_accessor :hosts_files
 			attr_accessor :id
 		end
 	end


### PR DESCRIPTION
In some instances (e.g. Laravel Homestead) there is a file called aliases used for other purposes.
